### PR TITLE
Fix link to GitHub repository

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Total duration: 4 hours
 ## Training materials
 
 All training materials are available in a 
-[GitHub repository](https://github.com/hpcleuven/Best-practices-for-data-science-on-HPC).
+[GitHub repository](https://github.com/gjbex/Best-practices-for-data-science-on-HPC).
 
 
 ## Target audience


### PR DESCRIPTION
The link to the repository in `docs/README.md` referred to the wrong namespace, this PR should fix that.

## Summary by Sourcery

Documentation:
- Correct GitHub repository URL in docs/README.md to reference the proper namespace.